### PR TITLE
feat: render nested tag spaces in Navigator

### DIFF
--- a/src/core/react/components/Navigator/SpaceTree/SpaceTreeView.tsx
+++ b/src/core/react/components/Navigator/SpaceTree/SpaceTreeView.tsx
@@ -138,8 +138,7 @@ const treeForRoot = (
       rank: null,
       collapsed: expandedSpaces.includes(space.path) ? false : true,
       sortable: space.sortable,
-      childrenCount: [...(superstate.spacesMap.getInverse(space.path) ?? [])]
-        .length,
+      childrenCount: superstate.getSpaceItems(space.path)?.length ?? 0,
       type: "group",
     });
   const spaceSort = space.metadata?.sort ?? defaultSpaceSort;

--- a/src/core/superstate/superstate.ts
+++ b/src/core/superstate/superstate.ts
@@ -36,7 +36,7 @@ import { EventDispatcher } from "shared/utils/dispatchers/dispatcher";
 import { safelyParseJSON } from "shared/utils/json";
 import { mdbSchemaToFrameSchema } from "shared/utils/makemd/schema";
 import { parseMultiString } from "utils/parsers";
-import { getAllParentTags } from "utils/tags";
+import { getAllParentTags, buildTagHierarchy } from "utils/tags";
 import { removeLinkInContexts, removePathInContexts, removeTagInContexts, renameLinkInContexts, renamePathInContexts, renameTagInContexts, updateContextWithProperties } from "../utils/contexts/context";
 import { API } from "./api";
 import { SpacesCommandsAdapter } from "./commands";
@@ -53,6 +53,7 @@ import { ISuperstate, PathStateWithRank } from "shared/types/superstate";
 import { getParentPathFromString } from "utils/path";
 import { parseMDBStringValue } from "utils/properties";
 import { fastSearch, searchPath } from "./workers/search/impl";
+import { TagNode } from "shared/types/tags";
 export type SuperProperty = {
     id: string,
     name: string,
@@ -130,6 +131,7 @@ public api: API;
     public spacesMap: IndexMap //file to space mapping
     public linksMap: IndexMap //link between paths
     public tagsMap: IndexMap //file to tag mapping
+    public tagHierarchy: TagNode[];
     public liveSpaceLinkMap: IndexMap
     //Workers
     public allMetadata: Record<string, {
@@ -202,6 +204,7 @@ public api: API;
         this.spacesMap = new IndexMap();
         this.linksMap = new IndexMap();
         this.tagsMap = new IndexMap();
+        this.tagHierarchy = [];
         this.liveSpaceLinkMap = new IndexMap();
 
         //Initiate Persistance
@@ -325,13 +328,38 @@ public api: API;
             ;
             
         await Promise.all(promises);
-        
+
+    }
+    private findTagChildren(tag: string, nodes: TagNode[]): TagNode[] {
+        for (const node of nodes) {
+            if (node.tag === tag) return node.children;
+            const res = this.findTagChildren(tag, node.children);
+            if (res) return res;
+        }
+        return [];
     }
 
     public  getSpaceItems(spacePath: string, filesOnly?: boolean) : PathStateWithRank[] {
         const items = [...this.spacesMap.getInverse(spacePath)]
+        if (!filesOnly) {
+            if (spacePath == tagsSpacePath) {
+                this.tagHierarchy
+                    .map((t) => tagSpacePathFromTag(t.tag))
+                    .forEach((p) => {
+                        if (!items.includes(p)) items.push(p);
+                    });
+            } else if (spacePath.startsWith('spaces://#')) {
+                const uri = this.spaceManager.uriByString(spacePath);
+                const tag = uri.authority + uri.path;
+                this.findTagChildren(tag, this.tagHierarchy)
+                    .map((t) => tagSpacePathFromTag(t.tag))
+                    .forEach((p) => {
+                        if (!items.includes(p)) items.push(p);
+                    });
+            }
+        }
         const ranks = this.contextsIndex.get(spacePath)?.paths ?? [];
-        
+
         return items.map<PathStateWithRank>((f, i) => {
             if (this.spacesIndex.has(f)) {
                 this.spaceManager.loadPath(this.spacesIndex.get(f).space.notePath);
@@ -339,7 +367,7 @@ public api: API;
                 this.spaceManager.loadPath(f);
             }
             const pathCache = this.pathsIndex.get(f);
-  
+
             return {
               ...pathCache,
               rank: ranks.indexOf(f),
@@ -419,8 +447,11 @@ public api: API;
     
     public async initializeTags() {
 
-        const allTags = this.spaceManager.readTags().map(f => tagSpacePathFromTag(f));
-        const promises = [...allTags].map(l => this.reloadPath(l, true));
+        const tags = this.spaceManager.readTags();
+        const withParents = uniq(tags.flatMap((t) => [t, ...getAllParentTags(t)]));
+        this.tagHierarchy = buildTagHierarchy(withParents);
+        const allTags = withParents.map((f) => tagSpacePathFromTag(f));
+        const promises = [...allTags].map((l) => this.reloadPath(l, true));
         await Promise.all(promises);
     }
 
@@ -966,14 +997,20 @@ public async updateSpaceMetadata (spacePath: string, metadata: SpaceDefinition) 
             if (!_.isEqual(cache.spaces, Array.from(this.spacesMap.get(path)))) {
                 this.spacesMap.set(path, new Set(cache.spaces))
                 //initiate missing tags
-                const promises = cache.tags.map(f => fileSystemSpaceInfoFromTag(this.spaceManager, f)).filter(f => !this.spacesIndex.has(f.path)).map(async f =>  
-                    {
+                const tagSet = new Set<string>();
+                cache.tags.forEach((t) => {
+                    tagSet.add(t);
+                    getAllParentTags(t).forEach((p) => tagSet.add(p));
+                });
+                const promises = [...tagSet]
+                    .map((f) => fileSystemSpaceInfoFromTag(this.spaceManager, f))
+                    .filter((f) => !this.spacesIndex.has(f.path))
+                    .map(async (f) => {
                         await this.reloadSpace(f);
                         this.reloadContext(f, { force: false, calculate: true });
                         await this.reloadPath(f.path);
-                        return 
-                    }
-                );
+                        return;
+                    });
                 const allPromises = Promise.all(promises)
                 await allPromises.then(f => {
                     this.dispatchEvent("spaceStateUpdated", {path: tagsSpacePath});

--- a/src/shared/types/superstate.ts
+++ b/src/shared/types/superstate.ts
@@ -16,6 +16,7 @@ import { ContextState, PathState, SpaceState, SuperstateEvent } from "./PathStat
 import { FilterGroupDef, SpaceDefinition } from "./spaceDef";
 import { SpaceInfo } from "./spaceInfo";
 import { SpaceManagerInterface } from "./spaceManager";
+import { TagNode } from "./tags";
 import { IUIManager } from "./uiManager";
 
 
@@ -47,6 +48,7 @@ export abstract class ISuperstate {
     spacesMap: IndexMap;
     linksMap: IndexMap;
     tagsMap: IndexMap;
+    tagHierarchy: TagNode[];
     liveSpaceLinkMap: IndexMap;
     allMetadata: Record<string, { name: string; properties: Metadata[] }>;
     focuses: Focus[];

--- a/src/shared/types/tags.ts
+++ b/src/shared/types/tags.ts
@@ -1,0 +1,4 @@
+export interface TagNode {
+  tag: string;
+  children: TagNode[];
+}

--- a/src/utils/tags.ts
+++ b/src/utils/tags.ts
@@ -1,5 +1,6 @@
 import { renameTagSpacePath } from "core/utils/contexts/optionValuesForColumn";
 import { Superstate } from "makemd-core";
+import { TagNode } from "shared/types/tags";
 import { pathToString } from "utils/path";
 import { encodeSpaceName } from "../core/utils/strings";
 
@@ -71,5 +72,35 @@ export const stringFromTag = (string: string) => {
   }
 
   return string;
+};
+
+export const buildTagHierarchy = (tags: string[]): TagNode[] => {
+  const root: Record<string, { node: TagNode; children: Record<string, any> }> = {};
+
+  for (const tag of tags) {
+    const parts = tag.replace(/^#/, "").split("/");
+    let current = root;
+    let currentPath = "";
+
+    for (const part of parts) {
+      currentPath = currentPath ? `${currentPath}/${part}` : part;
+      if (!current[part]) {
+        current[part] = {
+          node: { tag: `#${currentPath}`, children: [] },
+          children: {},
+        };
+      }
+      current = current[part].children;
+    }
+  }
+
+  const convert = (obj: Record<string, { node: TagNode; children: any }>): TagNode[] => {
+    return Object.values(obj).map((v) => ({
+      tag: v.node.tag,
+      children: convert(v.children),
+    }));
+  };
+
+  return convert(root);
 };
 


### PR DESCRIPTION
## Summary
- show child tag spaces by integrating tag hierarchy in `getSpaceItems`
- use `getSpaceItems` to count children, enabling nested tag rendering in the Navigator

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find module 'obsidian' or its type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_689dd063e650832282f6afa6c5e23bd1